### PR TITLE
Resolved #22 - Added more memory by default

### DIFF
--- a/novoalign/NovoAlign.wdl
+++ b/novoalign/NovoAlign.wdl
@@ -11,7 +11,7 @@ task NovoAlign {
   input {
     File ? novoalign
     File novoalign_license
-    File reference
+    File reference_novoindex
 
     String sample_id
     File fastq_1
@@ -40,7 +40,7 @@ task NovoAlign {
     cp ${novoalign_license} .;
 
     ${default="novoalign" novoalign} \
-      -d ${reference} \
+      -d ${reference_novoindex} \
       -f ${fastq_1} ${fastq_2} \
       -c ${cpu} \
       -o ${output_format} \
@@ -62,7 +62,7 @@ task NovoAlign {
   parameter_meta {
     novoalign: "NovoAlign executable."
     novoalign_license: "NovoAlign license."
-    reference: "Reference sequence file index with NovoIndex."
+    reference_novoindex: "Reference sequence file index with NovoIndex."
     sample_id: "Sample ID to use in SAM tag."
     fastq_1: "FASTQ Files left reads."
     fastq_2: "FASTQ Files right reads."


### PR DESCRIPTION
Renamed reference to reference_novoindex to avoid confusion. NovoAlign and Samtools use different references

Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *#22 - Added more memory to the piped version of NovoAlign + Samtools sort*
+ *renamed parameters to make sure it is clear what is a desired input*