### PR TITLE
Add new task for Picard: AddOrReplaceReadGroups

### DIFF
--- a/picard/AddOrReplaceReadGroups.wdl
+++ b/picard/AddOrReplaceReadGroups.wdl
@@ -1,0 +1,86 @@
+version 1.0
+# -------------------------------------------------------------------------------------------------
+# Package Name: https://broadinstitute.github.io/picard/
+# Task Summary: Add/replace read groups in a BAM file.
+# Tool Name: Picard AddOrReplaceReadGroups
+# Documentation: https://broadinstitute.github.io/picard/command-line-overview.html#AddOrReplaceReadGroups
+# -------------------------------------------------------------------------------------------------
+
+
+task AddOrReplaceReadGroups {
+  input {
+    File ? java
+    File ? picard
+
+    File input_bam
+    String sample_id
+    String output_filename_extension
+
+    Int RGID = 4
+    String RGLB = "lib1"
+    String RGPL = "illumina"
+    String RGPU = "unit1"
+    String RGSM = "20"
+
+    String ? userString
+
+    Array[String] modules = []
+    Int memory = 4
+    Int cpu = 1
+  }
+
+  String output_filename = "${sample_id}" + "${output_filename_extension}"
+
+  command {
+    set -Eeuxo pipefail;
+
+    for MODULE in ${sep=' ' modules}; do
+        module load $MODULE
+    done;
+
+    ${default="java" java} \
+      -Xmx${memory}g \
+      -jar ${default="picard" picard} AddOrRemoveReadGroups \
+      ${userString} \
+      -I=${input_bam} \
+      -O=${output_filename} \
+      -RGID=${RGID} \
+      -RGLB=${RGLB} \
+      -RGPL=${RGPL} \
+      -RGPU=${RGPU} \
+      -RGSM=${RGSM};
+  }
+
+	output {
+		File output_bam = "${output_filename}"
+	}
+
+	runtime {
+		memory: memory * 1.5 + " GB"
+		cpu: cpu
+	}
+
+	parameter_meta {
+		java: "Path to Java."
+    picard: "Picard jar file."
+		input_bam: "Sorted BAM file."
+		sample_id: "prefix for output files."
+    output_filename_extension: "Full BAM filename with extension change, e.g. .rg.bam"
+    RGID: "Read Group ID."
+    RGLB: "Read Group library."
+    RGPL: "Read Group platform."
+    RGPU: "Read Group platform unit."
+    RGSM: "Read Group sample name."
+    userString: "An optional parameter which allows the user to specify additions to the command line at run time."
+    modules: "Modules to load when task is called; modules must be compatible with the platform the task runs on."
+    memory: "GB of RAM to use at runtime."
+    cpu: "Number of CPUs to use at runtime."
+	}
+
+	meta {
+		author: "Mark Welsh"
+		email: "welshm3@email.chop.edu"
+		picard_version: "2.19.0"
+		version: "0.1.0"
+	}
+}

--- a/picard/AddOrReplaceReadGroups.wdl
+++ b/picard/AddOrReplaceReadGroups.wdl
@@ -14,7 +14,7 @@ task AddOrReplaceReadGroups {
 
     File input_bam
     String sample_id
-    String output_filename_extension
+    String output_filename_extension = ".rg.bam"
 
     Int RGID = 4
     String RGLB = "lib1"
@@ -65,7 +65,7 @@ task AddOrReplaceReadGroups {
     picard: "Picard jar file."
     input_bam: "Sorted BAM file."
     sample_id: "prefix for output files."
-    output_filename_extension: "Full BAM filename with extension change, e.g. .rg.bam"
+    output_filename_extension: "BAM filename extension, will default to <sample_id>.rg.bam"
     RGID: "Read Group ID."
     RGLB: "Read Group library."
     RGPL: "Read Group platform."

--- a/picard/AddOrReplaceReadGroups.wdl
+++ b/picard/AddOrReplaceReadGroups.wdl
@@ -42,13 +42,13 @@ task AddOrReplaceReadGroups {
       -Xmx${memory}g \
       -jar ${default="picard" picard} AddOrReplaceReadGroups \
       ${userString} \
-      -I=${input_bam} \
-      -O=${output_filename} \
-      -RGID=${RGID} \
-      -RGLB=${RGLB} \
-      -RGPL=${RGPL} \
-      -RGPU=${RGPU} \
-      -RGSM=${RGSM};
+      I=${input_bam} \
+      O=${output_filename} \
+      RGID=${RGID} \
+      RGLB=${RGLB} \
+      RGPL=${RGPL} \
+      RGPU=${RGPU} \
+      RGSM=${RGSM};
   }
 
 	output {

--- a/picard/AddOrReplaceReadGroups.wdl
+++ b/picard/AddOrReplaceReadGroups.wdl
@@ -61,10 +61,10 @@ task AddOrReplaceReadGroups {
 	}
 
 	parameter_meta {
-		java: "Path to Java."
+    java: "Path to Java."
     picard: "Picard jar file."
-		input_bam: "Sorted BAM file."
-		sample_id: "prefix for output files."
+    input_bam: "Sorted BAM file."
+    sample_id: "prefix for output files."
     output_filename_extension: "Full BAM filename with extension change, e.g. .rg.bam"
     RGID: "Read Group ID."
     RGLB: "Read Group library."

--- a/picard/AddOrReplaceReadGroups.wdl
+++ b/picard/AddOrReplaceReadGroups.wdl
@@ -40,7 +40,7 @@ task AddOrReplaceReadGroups {
 
     ${default="java" java} \
       -Xmx${memory}g \
-      -jar ${default="picard" picard} AddOrRemoveReadGroups \
+      -jar ${default="picard" picard} AddOrReplaceReadGroups \
       ${userString} \
       -I=${input_bam} \
       -O=${output_filename} \


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ #21 

Testing Done:
+ Works as intended in the RNA-Seq development pipeline

Notes:
+ since this task was created for the RNA-Seq pipeline, the default arguments represent parameters used in that pipeline only
+ the input and output bam filenames also are biased for RNA-Seq and attempt to avoid any need for string splitting, e.g. the `input_bam` is test001.Aligned.toTranscriptome.bam but the desired output bam name is test001.Aligned.toTranscriptome.rg.bam... the `input_bam` is passed as an argument but the name is "destroyed" in favor of being able to manufacture a new one using the `sample_id` and `output_filename_extension`