### PR TITLE
Resolved #25 - adds `--user` to pip install command. Allows pip to install in a local user dir

### DIFF
--- a/python/virtualenv.wdl
+++ b/python/virtualenv.wdl
@@ -25,7 +25,7 @@ task CreateVirtualenv {
     done;
 
     virtualenv --python=${version} ${name};
-    ${pip_filename} install -r ${requirements};
+    ${pip_filename} install --user -r ${requirements};
   }
 
   output {


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *#25 - added `--user` flag to correct `Could not install packages due to an EnvironmentError: [Errno 13] Permission denied:` error*

