### PR TITLE
Update SnpEff.wdl

### DIFF
--- a/snpeff/SnpEff.wdl
+++ b/snpeff/SnpEff.wdl
@@ -42,7 +42,7 @@ task SnpEff {
         -c ${config} \
         -dataDir ${dataDir} \
         ${reference_version} \
-        ${vcf_file} > ${output_filename};
+        ${input_file} > ${output_filename};
   }
 
   output {


### PR DESCRIPTION
SnpEff Tasks was trying to use an undefined parameter as input for command. By chance it was trying to use the output parameter name.  It was failing trying to localize a file that did not exist.