### PR TITLE
Add WDL task for samtools index

### DIFF
--- a/samtools/Index.wdl
+++ b/samtools/Index.wdl
@@ -1,0 +1,61 @@
+version 1.0
+# -------------------------------------------------------------------------------------------------
+# Package Name: http://www.htslib.org/
+# Tool Name: Samtools
+# Documentation: http://www.htslib.org/doc/samtools.html
+# -------------------------------------------------------------------------------------------------
+
+
+task Index {
+  input {
+    File ? samtools
+
+    String ? userString
+    File input_file
+    String output_file
+
+    Array[String] modules = []
+    Int memory = 4
+    Int cpu = 1
+  }
+
+  command {
+    set -Eeuxo pipefail;
+
+    for MODULE in ${sep=' ' modules}; do
+        module load $MODULE
+    done;
+
+    ${default="samtools" samtools} index \
+      ${"-@ " + cpu} \
+      ${userString} \
+      ${input_file} \
+      ${output_file}
+  }
+
+  output {
+    File output_idx_file = "${output_file}"
+  }
+
+  runtime {
+    memory: memory + " GB"
+    cpu: cpu
+  }
+
+  parameter_meta {
+    samtools: "Samtools executable."
+    userString: "An optional parameter which allows the user to specify additions to the command line at run time."
+    input_file: "Input file to process."
+    output_file: "Output index filename. Either set explicity here or let Samtools determine input filetype and index type."
+    modules: "Modules to load when task is called; modules must be compatible with the platform the task runs on."
+    memory: "GB of RAM to use at runtime."
+    cpu: "Number of CPUs to use at runtime."
+  }
+
+  meta {
+    author: "Mark Welsh"
+    email: "welshm3@email.chop.edu"
+    samtools_version: "1.9"
+    version: "0.1.0"
+  }
+}

--- a/samtools/Index.wdl
+++ b/samtools/Index.wdl
@@ -22,15 +22,15 @@ task Index {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ${sep=' ' modules}; do
+    for MODULE in ~{sep=' ' modules}; do
         module load $MODULE
     done;
 
-    ${default="samtools" samtools} index \
-      ${"-@ " + cpu} \
-      ${userString} \
-      ${input_file} \
-      ${output_file}
+    ~{default="samtools" samtools} index \
+      ~{"-@ " + cpu} \
+      ~{userString} \
+      ~{input_file} \
+      ~{output_file};
   }
 
   output {
@@ -46,7 +46,7 @@ task Index {
     samtools: "Samtools executable."
     userString: "An optional parameter which allows the user to specify additions to the command line at run time."
     input_file: "Input file to process."
-    output_file: "Output index filename. Either set explicity here or let Samtools determine input filetype and index type."
+    output_file: "Output index filename. Needs to be set explicitly."
     modules: "Modules to load when task is called; modules must be compatible with the platform the task runs on."
     memory: "GB of RAM to use at runtime."
     cpu: "Number of CPUs to use at runtime."


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *#29*

Testing Done:
+ created a dedicated WDL workflow that includes the upstream and downstream tasks that bookend the task made here
+ see this directory for results `/DGD/Research/welshm3/tests/rnaseq/wdl` 

I decided to make the output filename explicit. Relying on samtools to detect the input filetype (BAM, SAM, CRAM, etc.) is reliable but does not work when Cromwell goes to look for the output file. The changes merged here will resolve #29.
