### PR TITLE
Resolves #108 - Unload Python/2.7 module after pyenv is created

### DIFF
--- a/python/virtualenv.wdl
+++ b/python/virtualenv.wdl
@@ -8,8 +8,9 @@ task CreateVirtualenv {
     String version = 'python2.7'
     String name = 'pyenv'
     File requirements
+    Array[String] python_modules = ['python/2.7']
 
-    Array[String] modules = ['python/2.7']
+    Array[String] modules = []
     Float memory = 4
     Int cpu = 1
   }
@@ -21,7 +22,15 @@ task CreateVirtualenv {
         module load $MODULE
     done;
 
+    for PYTHON_MODULE in ~{sep=' ' python_modules}; do
+        module load $PYTHON_MODULE
+    done;
+
     virtualenv --python=~{version} ~{name};
+
+    for PYTHON_MODULE in ~{sep=' ' python_modules}; do
+        module unload $PYTHON_MODULE
+    done;
 
     source ~{name}/bin/activate;
 


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *#108*

Separates modules array from python modules array. The python modules
array is unloaded after the pyenv is created.

Testing Done:
+ RNASeq pipeline has no conflicting packages!