### PR TITLE
Resolves #113 - Adds tar command for compressing/archiving files & directory

### DIFF
--- a/unix/commands.wdl
+++ b/unix/commands.wdl
@@ -281,3 +281,19 @@ task sed {
     File output_file = "~{output_filename}"
   }
 }
+
+task tar {
+  input {
+    String input_file_or_directory
+    String output_filename
+    String userString = "-zcf"
+  }
+
+  command {
+    tar ~{userString} ~{output_filename} ~{input_file_or_directory}
+  }
+
+  output {
+    File output_file = "~{output_filename}"
+  }
+}

--- a/unix/commands.wdl
+++ b/unix/commands.wdl
@@ -284,13 +284,13 @@ task sed {
 
 task tar {
   input {
-    String input_file_or_directory
+    Array[String] input_files
     String output_filename
-    String userString = "-zcf"
+    String userString = "-zcvf"
   }
 
   command {
-    tar ~{userString} ~{output_filename} ~{input_file_or_directory}
+    tar ~{userString} ~{output_filename} ~{sep=" " input_files}
   }
 
   output {


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *#113*

Testing Done:
+ Ran successfully in 6 live RNASeq pipelines

Notes:
+ `tar` takes a full path and rebuilds the directory structure within the tarball. This is a feature and not a bug. This means when untarring, in any directory, the directory will look like `/scr1/users/svcdgdbfx` when tarring files 