### PR TITLE
output_filename_prefix is needed for mito pipeline

### DIFF
--- a/novoalign/NovoAlignAndSamtoolsSort.wdl
+++ b/novoalign/NovoAlignAndSamtoolsSort.wdl
@@ -35,9 +35,11 @@ task NovoAlignAndSamtoolsSort {
     Int cpu = 16
     Boolean debug = false
 
-    String output_filename = sample_id + ".sorted.bam"
-    String output_idx_filename = sample_id + ".sorted.bam.bai"
-    String output_alignment_stats = sample_id + ".alignment.stats"
+    String output_filename_prefix = sample_id
+
+    String output_filename = output_filename_prefix + ".sorted.bam"
+    String output_idx_filename = output_filename_prefix + ".sorted.bam.bai"
+    String output_alignment_stats = output_filename_prefix + ".alignment.stats"
   }
 
   command {


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
- output_filename_prefix is needed to differentiate 2 different novoalign bam files. The bam file for CNV calculation will be called "shifted" check [here](https://github.research.chop.edu/DGD/dgd-wdl-workflows/blob/develop/workflows/mito.wdl#L142-L143)

