### PR TITLE
Disable M5 tag #160

### DIFF
--- a/novoalign/NovoAlign.wdl
+++ b/novoalign/NovoAlign.wdl
@@ -22,7 +22,7 @@ task NovoAlign {
     String platform = "PL"
     String platform_unit = "PU"
 
-    String userString = "-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP -p 5,20 -k"
+    String userString = "-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off -k"
 
     Array[String] modules = []
     Float memory = 30

--- a/novoalign/NovoAlign.wdl
+++ b/novoalign/NovoAlign.wdl
@@ -22,7 +22,7 @@ task NovoAlign {
     String platform = "PL"
     String platform_unit = "PU"
 
-    String userString = "-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off -k"
+    String userString = "-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off --addM5 off -k"
 
     Array[String] modules = []
     Float memory = 30

--- a/novoalign/NovoAlignAndSamtoolsSort.wdl
+++ b/novoalign/NovoAlignAndSamtoolsSort.wdl
@@ -26,7 +26,7 @@ task NovoAlignAndSamtoolsSort {
     String platform = "PL"
     String platform_unit = "PU"
 
-    String userString = "-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP -p 5,20 -k"
+    String userString = "-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off -k"
     String ? Samtools_view_parameters
     String ? Samtools_sort_parameters
 
@@ -108,9 +108,9 @@ task NovoAlignAndSamtoolsSort {
   }
 
   meta {
-    author: "Michael A. Gonzalez"
-    email: "GonzalezMA@email.chop.edu"
-    novoalign_version: "3.06.01"
+    author: "Michael A. Gonzalez, Tolga Ayazseven"
+    email: "GonzalezMA@email.chop.edu, ayazsevent@chop.edu"
+    novoalign_version: "4.03.02"
     version: "0.1.0"
   }
 }

--- a/novoalign/NovoAlignAndSamtoolsSort.wdl
+++ b/novoalign/NovoAlignAndSamtoolsSort.wdl
@@ -26,7 +26,7 @@ task NovoAlignAndSamtoolsSort {
     String platform = "PL"
     String platform_unit = "PU"
 
-    String userString = "-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off -k"
+    String userString = "-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off --addM5 off -k"
     String ? Samtools_view_parameters
     String ? Samtools_sort_parameters
 

--- a/subworkflows/NovoAlign-FastQToBAM-BAMQC.wdl
+++ b/subworkflows/NovoAlign-FastQToBAM-BAMQC.wdl
@@ -8,7 +8,8 @@ version 1.0
 # -------------------------------------------------------------------------------------------------
 
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/utilities/CombineFastQ.wdl" as CombineFastQ
-import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/novoalign/NovoAlignAndSamtoolsSort.wdl" as NovoAlign
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/develop/utilities/novoalign-select-userstring.wdl" as SelectPlatform
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/develop/novoalign/NovoAlignAndSamtoolsSort.wdl" as NovoAlign
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/picard/MarkDuplicates.wdl" as Picard
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/subworkflows/BAM-Quality-Control.wdl" as BAMQualityControl
 
@@ -19,6 +20,7 @@ workflow FastQToBAM {
     Array[File] additional_fastq1
     File fastq_2
     Array[File] additional_fastq2
+    String platform
 
     File ? java
     File ? novoalign
@@ -55,6 +57,11 @@ workflow FastQToBAM {
       additional_fastq=additional_fastq2,
   }
 
+  call SelectPlatform.SelectPlatform {
+    input:
+      platform=platform,
+  }
+
   call NovoAlign.NovoAlignAndSamtoolsSort as Alignment {
     input:
       novoalign=novoalign,
@@ -64,6 +71,7 @@ workflow FastQToBAM {
       reference=reference,
       reference_idx=reference_idx,
       sample_id=sample_id,
+      userString=SelectPlatform.userString,
       fastq_1=CombineRead1.output_file,
       fastq_2=CombineRead2.output_file,
   }

--- a/subworkflows/NovoAlign-FastQToBAM.wdl
+++ b/subworkflows/NovoAlign-FastQToBAM.wdl
@@ -8,7 +8,8 @@ version 1.0
 # -------------------------------------------------------------------------------------------------
 
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/utilities/CombineFastQ.wdl" as CombineFastQ
-import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/novoalign/NovoAlignAndSamtoolsSort.wdl" as NovoAlign
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/develop/utilities/novoalign-select-userstring.wdl" as SelectPlatform
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/develop/novoalign/NovoAlignAndSamtoolsSort.wdl" as NovoAlign
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/picard/MarkDuplicates.wdl" as Picard
 
 workflow FastQToBAM {
@@ -18,6 +19,7 @@ workflow FastQToBAM {
     Array[File] additional_fastq1
     File fastq_2
     Array[File] additional_fastq2
+    String platform
 
     File ? novoalign
     File novoalign_license
@@ -41,6 +43,11 @@ workflow FastQToBAM {
       additional_fastq=additional_fastq2,
   }
 
+  call SelectPlatform.SelectPlatform {
+    input:
+      platform=platform,
+  }
+
   call NovoAlign.NovoAlignAndSamtoolsSort as Alignment {
     input:
       novoalign=novoalign,
@@ -50,6 +57,7 @@ workflow FastQToBAM {
       reference=reference,
       reference_idx=reference_idx,
       sample_id=sample_id,
+      userString=SelectPlatform.userString,
       fastq_1=CombineRead1.output_file,
       fastq_2=CombineRead2.output_file,
   }

--- a/subworkflows/NovoAlign-GATK-FastQToGVCF-BAMQC.wdl
+++ b/subworkflows/NovoAlign-GATK-FastQToGVCF-BAMQC.wdl
@@ -12,7 +12,8 @@ version 1.0
 # -------------------------------------------------------------------------------------------------
 
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/utilities/CombineFastQ.wdl" as CombineFastQ
-import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/novoalign/NovoAlignAndSamtoolsSort.wdl" as NovoAlign
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/develop/utilities/novoalign-select-userstring.wdl" as SelectPlatform
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/develop/novoalign/NovoAlignAndSamtoolsSort.wdl" as NovoAlign
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/picard/MarkDuplicates.wdl" as Picard
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/gatk/HaplotypeCallerERC.wdl" as GATK
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/subworkflows/BAM-Quality-Control.wdl" as BAMQualityControl
@@ -24,6 +25,7 @@ workflow FastQToGVCFAndBAMQC {
     Array[File] additional_fastq1
     File fastq_2
     Array[File] additional_fastq2
+    String platform
 
     File ? java
     File ? novoalign
@@ -61,12 +63,18 @@ workflow FastQToGVCFAndBAMQC {
       additional_fastq=additional_fastq2,
   }
 
+  call SelectPlatform.SelectPlatform {
+    input:
+      platform=platform,
+  }
+
   call NovoAlign.NovoAlignAndSamtoolsSort as Alignment {
     input:
       novoalign=novoalign,
       novoalign_license=novoalign_license,
       samtools=samtools,
       reference_novoindex=reference_novoindex,
+      userString=SelectPlatform.userString,
       reference=reference,
       reference_idx=reference_idx,
       sample_id=sample_id,

--- a/subworkflows/NovoAlign-GSNAP-FastQToBAM.wdl
+++ b/subworkflows/NovoAlign-GSNAP-FastQToBAM.wdl
@@ -8,7 +8,7 @@ version 1.0
 # -------------------------------------------------------------------------------------------------
 
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/utilities/CombineFastQ.wdl" as CombineFastQ
-import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/novoalign/NovoAlignAndSamtoolsSort.wdl" as NovoAlign
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/develop/novoalign/NovoAlignAndSamtoolsSort.wdl" as NovoAlign
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/gsnap/GsnapAndSamtools.wdl" as Gsnap
 
 workflow FastQGsnapToBAM {

--- a/utilities/novoalign-select-userstring.wdl
+++ b/utilities/novoalign-select-userstring.wdl
@@ -10,8 +10,8 @@ task SelectPlatform {
     Array[String] novaseq_platforms = ["DGDNovaSeq"]
 
     # UserStrings based on sequencing platform
-    String novaseq_userString = '"-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off -k"'
-    String hiseq_userString = '"-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off -k"'
+    String novaseq_userString = '"-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off --addM5 off -k"'
+    String hiseq_userString = '"-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off --addM5 off -k"'
 
     # Run time variables
     Float memory = 12

--- a/utilities/novoalign-select-userstring.wdl
+++ b/utilities/novoalign-select-userstring.wdl
@@ -1,0 +1,42 @@
+
+version 1.0
+# -------------------------------------------------------------------------------------------------
+# Task to handle Novoalign userString selection based on sequencing platfrom
+# -------------------------------------------------------------------------------------------------
+
+task SelectPlatform {
+  input {
+    String platform
+    Array[String] novaseq_platforms = ["DGDNovaSeq"]
+
+    # UserStrings based on sequencing platform
+    String novaseq_userString = '"-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off -k"'
+    String hiseq_userString = '"-i PE 240,150 -r All 5 -R 60 -t 15,2 -H 20 99999 --hlimit 7 --trim3HP ACGT -p 5,20 -x 6 --softclip 0,0 -v 70 --pechimera off -k"'
+
+    # Run time variables
+    Float memory = 12
+    Int cpu = 1
+    Array[String] modules = []
+  }
+
+  command <<<
+    if [[ "~{sep=" " novaseq_platforms}" =~ "~{platform}" ]]
+    then
+      USERSTRING=~{novaseq_userString}
+    else
+      USERSTRING=~{hiseq_userString}
+    fi
+
+    echo "$USERSTRING"
+  >>>
+
+  output {
+    String userString = read_lines(stdout())[0]
+  }
+
+  meta {
+    author: "Tolga Ayazseven"
+    email: "ayazsevent@email.chop.edu"
+    version: "0.1.0"
+  }
+}


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
#160 

Testing Done:
Add `--addM5 off` to disable M5 tags in bam files from running novoalign V4

