### PR TITLE
Rhel9 updates

### DIFF
--- a/gatk/DepthOfCoverage.wdl
+++ b/gatk/DepthOfCoverage.wdl
@@ -24,7 +24,7 @@ task DepthOfCoverage {
     Array[File] bam_idx_files
 
     Array[Int] summary_coverage_threshold = [15]
-    String userString = "-omitBaseOutput -omitLocusTable"
+    String userString = "-omit-depth-output-at-each-base -omit-locus-table"
 
     Array[String] modules = []
     Float memory = 12
@@ -43,17 +43,15 @@ task DepthOfCoverage {
       module load $MODULE
     done;
 
-    ~{default="java" java} \
-      -Xmx~{jvm_memory}g \
-      -jar ~{default="gatk" gatk} \
-      -T DepthOfCoverage \
+   ~{default="gatk" gatk} \
+      DepthOfCoverage \
       ~{userString} \
       -R ~{reference} \
       ~{"-geneList " + gene_list} \
-      ~{sep=" " prefix("-ct ", summary_coverage_threshold)} \
+      ~{sep=" " prefix("--summary-coverage-threshold ", summary_coverage_threshold)} \
       ~{sep=" " prefix("-I ", bam_files)} \
       ~{sep=" " intervalOptions} \
-      -o ~{output_base_filename};
+      -O ~{output_base_filename};
   }
 
   output {

--- a/gatk/GenotypeGVCFs.wdl
+++ b/gatk/GenotypeGVCFs.wdl
@@ -45,18 +45,15 @@ task GenotypeGVCFs {
       module load $MODULE
     done;
 
-    ~{default="java" java} \
-      -Xmx~{jvm_memory}g \
-      -jar ~{default="gatk" gatk} \
-      -T GenotypeGVCFs \
+    ~{default="gatk" gatk} \
+      GenotypeGVCFs \
       ~{userString} \
-      -stand_call_conf ~{stand_call_conf} \
+      -stand-call-conf ~{stand_call_conf} \
       ~{"--dbsnp " + dbsnp} \
-      -nt ~{cpu} \
       -R ~{reference} \
       ~{sep=" " prefix("--variant ", gvcf_files)} \
       ~{sep=" " intervalOptions} \
-      -o ~{vcf_filename};
+      -O ~{vcf_filename};
   }
 
   output {

--- a/gatk/HaplotypeCallerERC.wdl
+++ b/gatk/HaplotypeCallerERC.wdl
@@ -47,17 +47,14 @@ task HaplotypeCallerERC {
       module load $MODULE
     done;
 
-    ~{default="java" java} \
-      -Xmx~{jvm_memory}g \
-      -jar ~{default="gatk" gatk} \
-      -T HaplotypeCaller -ERC GVCF \
+    ~{default="gatk" gatk} \
+      HaplotypeCaller -ERC GVCF \
       ~{userString} \
-      -nct ~{cpu} \
       ~{"--dbsnp " + dbsnp} \
       -R ~{reference} \
       -I ~{bam_file} \
       ~{sep=" " intervalOptions} \
-      -o ~{gvcf_filename};
+      -O ~{gvcf_filename};
   }
 
   output {

--- a/penncnv/DetectCNVs.wdl
+++ b/penncnv/DetectCNVs.wdl
@@ -20,7 +20,6 @@ task DetectCNVs {
     # Run time variables
     Float memory = 12
     Int cpu = 1
-    Array[String] modules = []
 
     String output_filename
   }

--- a/penncnv/DetectCNVs.wdl
+++ b/penncnv/DetectCNVs.wdl
@@ -8,7 +8,8 @@ version 1.0
 
 task DetectCNVs {
   input {
-    String script  # NOTE: PennCNV needs to run in its own folder
+    String ? script = "/home/user/PennCNV/detect_cnv.pl"
+    String image
     String input_file
     File hmm_file
     File pfb_file
@@ -27,11 +28,7 @@ task DetectCNVs {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-      module load $MODULE
-    done;
-
-    perl ~{script} \
+    ~{script} \
       -test \
       ~{input_file} \
       ~{sex_flag} \
@@ -49,10 +46,13 @@ task DetectCNVs {
   runtime {
     memory: memory + " GB"
     cpu: cpu
+    singularity: true
+    image: image
   }
 
   parameter_meta {
-    script: "Path to penncnv detect_cnv.pl script"
+    script: "Path to penncnv detect_cnv.pl script in Singularity image"
+    image: "Path to singularity image"
     input_file: "GenomeStudio SNP Array Data"
     hmm_file: "penncnv hmm file"
     pfb_file: "penncnv pfb file"

--- a/penncnv/MergeCNV.wdl
+++ b/penncnv/MergeCNV.wdl
@@ -8,14 +8,14 @@ version 1.0
 
 task MergeCNV {
   input {
-    String script  # NOTE: PennCNV needs to run in its own folder
+    String script = "/home/user/PennCNV/clean_cnv.pl"
+    String image
     String input_file
     File signal_file
 
     # Run time variables
     Float memory = 12
     Int cpu = 1
-    Array[String] modules = []
 
     String output_filename = "merged_cnv_calls.tsv"
   }
@@ -23,11 +23,7 @@ task MergeCNV {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-      module load $MODULE
-    done;
-
-    perl ~{script} \
+    ~{script} \
       combineseg \
       ~{input_file} \
       --signalfile \
@@ -43,10 +39,13 @@ task MergeCNV {
   runtime {
     memory: memory + " GB"
     cpu: cpu
+    singularity: true
+    image: image
   }
 
   parameter_meta {
-    script: "Path to penncnv clean_cnv.pl script"
+    script: "Path to penncnv clean_cnv.pl script in Singularity image"
+    image: "Path to Singularity image"
     input_file: "PennCNV raw CNV file"
     signal_file: "Genome Studio SNP Array file"
     output_filename: "Output filename"

--- a/penncnv/ScanRegion.wdl
+++ b/penncnv/ScanRegion.wdl
@@ -16,7 +16,6 @@ task ScanRegion {
     # Run time variables
     Float memory = 12
     Int cpu = 1
-    Array[String] modules = []
   }
 
   command {

--- a/penncnv/ScanRegion.wdl
+++ b/penncnv/ScanRegion.wdl
@@ -8,7 +8,8 @@ version 1.0
 
 task ScanRegion {
   input {
-    String script  # NOTE: PennCNV needs to run in its own folder
+    String script = "/home/user/PennCNV/scan_region.pl"
+    String image
     String input_file
     File refgene_file
 
@@ -21,11 +22,7 @@ task ScanRegion {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-      module load $MODULE
-    done;
-
-    perl ~{script} \
+    ~{script} \
       ~{input_file} \
       ~{refgene_file} \
       -refgene \
@@ -39,10 +36,13 @@ task ScanRegion {
   runtime {
     memory: memory + " GB"
     cpu: cpu
+    singularity: true
+    image: image
   }
 
   parameter_meta {
-    script: "Path to penncnv scan_region.pl script"
+    script: "Path to penncnv scan_region.pl script in Singularity image"
+    image: "Path to Singularity image"
     input_file: "GenomeStudio SNP Array Data"
     refgene_file: "UCSC refGene.txt"
     memory: "GB of RAM to use at runtime."

--- a/penncnv/VisualizeCNV.wdl
+++ b/penncnv/VisualizeCNV.wdl
@@ -8,14 +8,14 @@ version 1.0
 
 task VisualizeCNV {
   input {
-    String script  # NOTE: PennCNV needs to run in its own folder
+    String script = "/home/user/PennCNV/visualize_cnv.pl"
+    String image
     String input_file
     File idmap_file
 
     # Run time variables
     Float memory = 12
     Int cpu = 1
-    Array[String] modules = []
 
     String output_filename = "project_cnvs.xml"
   }
@@ -23,11 +23,7 @@ task VisualizeCNV {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-      module load $MODULE
-    done;
-
-    perl ~{script} \
+    ~{script} \
       -format beadstudio \
       -idmap \
       ~{idmap_file} \
@@ -43,10 +39,13 @@ task VisualizeCNV {
   runtime {
     memory: memory + " GB"
     cpu: cpu
+    singularity: true
+    image: image
   }
 
   parameter_meta {
-    script: "PAth to penncnv visualize_cnv.pl script"
+    script: "Path to penncnv visualize_cnv.pl script in Singularity image"
+    image: "Path to Singularity image"
     input_file: "PennCNV raw CNV file"
     idmap_file: "a file containing file name (in PennCNV call) and sample id (in BeadStudio) mapping"
     output_filename: "Output filename"

--- a/pindel/Pindel.wdl
+++ b/pindel/Pindel.wdl
@@ -31,13 +31,9 @@ task Pindel {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-        module load $MODULE
-    done;
-
     echo -e ~{bam_file}"\t"~{sliding_window}"\t"~{sample_id} > config;
 
-    ~{default="pindel" pindel} \
+    pindel \
       ~{userString} \
       ~{"-j " + intervals} \
       -f ~{reference} \
@@ -60,6 +56,8 @@ task Pindel {
   runtime {
     memory: memory + " GB"
     cpu: cpu
+    singularity: true
+    image: pindel
   }
 
   parameter_meta {

--- a/pindel/Pindel2VCF.wdl
+++ b/pindel/Pindel2VCF.wdl
@@ -30,13 +30,9 @@ task Pindel2Vcf {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-        module load $MODULE
-    done;
-
     cp ~{input_file} ~{temp_filename};
 
-    ~{default="pindel2vcf" pindel2vcf} \
+    /opt/pindel-0.2.5b8/pindel2vcf \
       ~{userString} \
       -r ~{reference} \
       -R ~{reference_version} \
@@ -51,6 +47,8 @@ task Pindel2Vcf {
   runtime {
     memory: memory + " GB"
     cpu: cpu
+    singularity: true
+    image: pindel2vcf
   }
 
   parameter_meta {

--- a/python/virtualenv.wdl
+++ b/python/virtualenv.wdl
@@ -28,7 +28,7 @@ task CreateVirtualenv {
         module load $PYTHON_MODULE
     done;
 
-    virtualenv ~{if version then "--python"version else ""} ~{name};
+    virtualenv ~{if version then "--python" + version else ""} ~{name};
 
     source ~{name}/bin/activate;
     ~{python_binary} -m pip install setuptools==57.5.0

--- a/python/virtualenv.wdl
+++ b/python/virtualenv.wdl
@@ -5,7 +5,7 @@ version 1.0
 
 task CreateVirtualenv {
   input {
-    String version = 'python3.9'
+    String ? version
     String name = 'pyenv'
     File requirements
     Array[String] python_modules = ['python39']
@@ -28,11 +28,7 @@ task CreateVirtualenv {
         module load $PYTHON_MODULE
     done;
 
-    virtualenv --python=~{version} ~{name};
-
-    for PYTHON_MODULE in ~{sep=' ' python_modules}; do
-        module unload $PYTHON_MODULE
-    done;
+    virtualenv ~{if version then "--python"version else ""} ~{name};
 
     source ~{name}/bin/activate;
     ~{python_binary} -m pip install setuptools==57.5.0

--- a/python/virtualenv.wdl
+++ b/python/virtualenv.wdl
@@ -17,6 +17,8 @@ task CreateVirtualenv {
     String python_binary = name + "/bin/python"
   }
 
+  String version_arg = if defined(version) then "--python=" + version else ""
+
   command {
     set -Eexo pipefail;
 
@@ -28,7 +30,7 @@ task CreateVirtualenv {
         module load $PYTHON_MODULE
     done;
 
-    virtualenv ~{if version then "--python" + version else ""} ~{name};
+    virtualenv ~{version_arg} ~{name};
 
     source ~{name}/bin/activate;
     ~{python_binary} -m pip install setuptools==57.5.0

--- a/python/virtualenv.wdl
+++ b/python/virtualenv.wdl
@@ -8,7 +8,7 @@ task CreateVirtualenv {
     String ? version
     String name = 'pyenv'
     File requirements
-    Array[String] python_modules = ['python39']
+    Array[String] python_modules = ['Python/3.9.6-GCCcore-11.2.0-bare']
 
     Array[String] modules = []
     Float memory = 16

--- a/rsem/rsem-calc-expression.wdl
+++ b/rsem/rsem-calc-expression.wdl
@@ -17,7 +17,6 @@ task RSEMExpr {
 
     String userString = "--paired-end --no-bam-output --no-qualities"
 
-    Array[String] modules = []
     Float memory = 24
     Int cpu = 12
   }
@@ -25,11 +24,7 @@ task RSEMExpr {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-        module load $MODULE
-    done;
-
-    ~{rsem} \
+    rsem-calculate-expression \
       --num-threads ~{cpu} \
       ~{userString} \
       --forward-prob ~{forward_prob} \
@@ -44,17 +39,18 @@ task RSEMExpr {
   }
 
   runtime {
+    singularity: true
+    image: rsem
     memory: memory + " GB"
     cpu: cpu
   }
 
   parameter_meta {
-    rsem: "Path to rsem-calculate-expression."
+    rsem: "Path to rsem image."
     bam_file: "Aligned transcriptome BAM."
     reference_directory: "pre-built reference directory; built with rsem-prepare-reference."
     sample_id: "prefix for output files."
     forward_prob: "Probability of generating a read from the forward strand of a transcript."
-    modules: "Modules to load when task is called; modules must be compatible with the platform the task runs on."
     memory: "GB of RAM to use at runtime."
     cpu: "Number of CPUs to use at runtime."
   }

--- a/scalpel/Single.wdl
+++ b/scalpel/Single.wdl
@@ -34,11 +34,7 @@ task Single {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-        module load $MODULE
-    done;
-
-    ~{default="scalpel" scalpel} --single \
+    /opt/scalpel-0.5.4/scalpel-discovery --single \
       --ref ~{reference} \
       --bam ~{bam_file} \
       --bed ~{intervals} \
@@ -54,6 +50,8 @@ task Single {
   runtime {
     memory: memory + " GB"
     cpu: cpu
+    singularity: true
+    image: scalpel
   }
 
   parameter_meta {

--- a/star-align/star-align-samtools-index.wdl
+++ b/star-align/star-align-samtools-index.wdl
@@ -10,8 +10,7 @@ version 1.0
 
 task STARAlignSamToolsIndex {
   input {
-    File ? staralign
-    File ? samtools
+    File staralign
     String sample_id
 
     File fastq_1
@@ -39,7 +38,6 @@ task STARAlignSamToolsIndex {
 
     String ? userString
 
-    Array[String] modules = []
     Float memory = 48
     Int cpu = 12
   }
@@ -47,11 +45,7 @@ task STARAlignSamToolsIndex {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-        module load $MODULE
-    done;
-
-    ~{default="STAR" staralign} \
+    STAR \
       --runMode alignReads \
       --genomeDir ~{reference_directory} \
       --readFilesIn ~{fastq_1} ~{fastq_2} \
@@ -80,7 +74,7 @@ task STARAlignSamToolsIndex {
       ~{userString} \
       --twopassMode Basic;
 
-    ~{default="samtools" samtools} index \
+    samtools index \
       -@ ~{cpu} \
       Aligned.sortedByCoord.out.bam \
       Aligned.sortedByCoord.out.bam.bai;
@@ -97,12 +91,14 @@ task STARAlignSamToolsIndex {
   }
 
   runtime {
+    singularity: true
+    image: staralign
     memory: memory + " GB"
     cpu: cpu
   }
 
   parameter_meta {
-    staralign: "Path to STAR binary."
+    staralign: "Path to STAR image."
     sample_id: "Prefix for output files."
     reference_directory: "Directory where the STAR reference index was created using STAR --genomeGenerate."
     readFilesCommand: "Shell command to read the fastqs in, e.g. zcat if fastqs are compressed."

--- a/star-fusion/star-fusion-samtools-sort-index.wdl
+++ b/star-fusion/star-fusion-samtools-sort-index.wdl
@@ -11,9 +11,6 @@ version 1.0
 task STARFusionSamToolsSortIndex {
   input {
     String starfusion
-    String ? staralign_path
-    File ? samtools
-    File ? samtools_path
 
     File fastq_1
     File fastq_2
@@ -22,7 +19,6 @@ task STARFusionSamToolsSortIndex {
 
     String userString = "--examine_coding_effect"
 
-    Array[String] modules = []
     Float memory = 48
     Int cpu = 12
   }
@@ -30,27 +26,20 @@ task STARFusionSamToolsSortIndex {
   command {
     set -Eeuxo pipefail;
 
-    for MODULE in ~{sep=' ' modules}; do
-        module load $MODULE
-    done;
-
-    PATH=~{staralign_path}:$PATH
-    PATH=~{samtools_path}:$PATH
-
-    ~{starfusion} \
+    /usr/local/src/STAR-Fusion/STAR-Fusion \
       --genome_lib_dir ~{reference_directory} \
       ~{userString} \
       --left_fq ~{fastq_1} \
       --right_fq ~{fastq_2} \
       --CPU ~{cpu};
 
-    ~{default="samtools" samtools} sort \
+    samtools sort \
       -@ ~{cpu} \
       -O bam \
       -o STAR-Fusion_outdir/Aligned.out.sorted.bam \
       STAR-Fusion_outdir/Aligned.out.bam;
 
-    ~{default="samtools" samtools} index \
+    samtools index \
       -@ ~{cpu} \
       STAR-Fusion_outdir/Aligned.out.sorted.bam \
       STAR-Fusion_outdir/Aligned.out.sorted.bam.bai;
@@ -69,13 +58,12 @@ task STARFusionSamToolsSortIndex {
   runtime {
     memory: memory + " GB"
     cpu: cpu
+    singularity: true
+    image: starfusion
   }
 
   parameter_meta {
-    starfusion: "Path to STAR-Fusion."
-    samtools: "Path to samtools binary."
-    staralign_path: "Path to STAR-Align directory, not binary."
-    samtools_path: "Path to samtools directory, not binary."
+    starfusion: "Path to STAR-Fusion image."
     reference_directory: "Fusion genome reference directory."
     memory: "GB of RAM to use at runtime."
     cpu: "Number of CPUs to use at runtime."

--- a/subworkflows/BAM-Quality-Control.wdl
+++ b/subworkflows/BAM-Quality-Control.wdl
@@ -8,7 +8,7 @@ version 1.0
 # -------------------------------------------------------------------------------------------------
 
 
-import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/gatk/DepthOfCoverage.wdl" as DepthOfCoverage
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/rhel9-updates/gatk/DepthOfCoverage.wdl" as DepthOfCoverage
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/picard/CollectHsMetrics.wdl" as CollectHsMetrics
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/verifybamid/VerifyBamId.wdl" as VerifyBamId
 

--- a/subworkflows/BAM-Quality-Control.wdl
+++ b/subworkflows/BAM-Quality-Control.wdl
@@ -8,7 +8,7 @@ version 1.0
 # -------------------------------------------------------------------------------------------------
 
 
-import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/rhel9-updates/gatk/DepthOfCoverage.wdl" as DepthOfCoverage
+import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.9.0/gatk/DepthOfCoverage.wdl" as DepthOfCoverage
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/picard/CollectHsMetrics.wdl" as CollectHsMetrics
 import "https://raw.githubusercontent.com/chopdgd/bfx-tools-wdl/v1.4.1/verifybamid/VerifyBamId.wdl" as VerifyBamId
 

--- a/unix/commands.wdl
+++ b/unix/commands.wdl
@@ -10,7 +10,6 @@ task awk {
     Array[String] ? input_files
     String output_filename
 
-    String queue = "defq,dgdq"
     Float memory = 1
     Int cpu = 1
   }
@@ -34,7 +33,6 @@ task wget {
     String url
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -60,7 +58,6 @@ task mkdir {
     String directory
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -85,7 +82,6 @@ task mv {
     String target
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -110,7 +106,6 @@ task cp {
     String target
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -135,7 +130,6 @@ task rsync {
     String target
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -160,7 +154,6 @@ task md5sum {
     String md5sum_file
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -186,7 +179,6 @@ task Install {
     String target
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -211,7 +203,6 @@ task UnZip {
     String ? userString
     String output_filename = basename(input_file, ".gz")
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -238,8 +229,6 @@ task BgZip {
     String output_filename = basename(input_file) + ".gz"
 
     Array[String] modules = []
-
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -275,7 +264,6 @@ task Tabix {
 
     Array[String] modules = []
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -315,7 +303,6 @@ task CompressAndIndex {
 
     Array[String] modules = []
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -356,7 +343,6 @@ task cut {
     String ? delimiter
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -382,7 +368,6 @@ task sort {
 
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -409,7 +394,6 @@ task cat {
 		Array[String] ? input_files
 		String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
 	}
@@ -434,7 +418,6 @@ task sed {
     String output_filename
     String command
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -459,7 +442,6 @@ task tar {
     String output_filename
     String userString = "-zcvf"
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
   }
@@ -484,7 +466,6 @@ task grep {
     String output_filename
 		String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
 	}
@@ -509,7 +490,6 @@ task zgrep {
     String output_filename
 		String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
 	}
@@ -534,7 +514,6 @@ task echo {
     String output_filename
     String ? userString
 
-    String queue = "defq,dgdq"
     Float memory = 12
     Int cpu = 1
 	}


### PR DESCRIPTION
- Remove default queues from Unix commands
- Use singularity images for some tools (pindel, penncnv, scalpel, rsem, staralign, star-fusion)
- Update CreateVirtualEnv to work on RHEL9 cluster
- Update some GATK tools to run with GATK4.2 (DepthOfCoverage, GenotypeGVCFs, HaplotypeCaller)